### PR TITLE
Bareword must follow require in expression.

### DIFF
--- a/corpus/state_require.pm
+++ b/corpus/state_require.pm
@@ -5,4 +5,8 @@ sub do_it {
 
 my $rc = require Mojo::Util;
 
+my %data = (
+    require	=> 42,	# Should not report '=>'.
+);
+
 1;

--- a/lib/Module/Extract/Use.pm
+++ b/lib/Module/Extract/Use.pm
@@ -259,8 +259,11 @@ sub _expression_load {
 
 	my $in_statements = $Document->find(
 		sub {
+			my $sib;
 			$_[1]->isa( 'PPI::Token::Word' ) &&
-			$_[1]->content eq 'require'
+			$_[1]->content eq 'require' &&
+			( $sib = $_[1]->snext_sibling() ) &&
+			$sib->isa( 'PPI::Token::Word' )
 			}
 		);
 


### PR DESCRIPTION
Otherwise we report things like { require => 42 } as requiring module '=>'.