### PR TITLE
Fix t/rt/79273.t, broken in 1.049

### DIFF
--- a/t/rt/79273.t
+++ b/t/rt/79273.t
@@ -29,7 +29,7 @@ is_deeply( $details, expected(), 'The data structures match' );
 sub expected {
 	return  [
 		{
-			'direct'  => 0,
+			'direct'  => 1,
 			'content' => q(use parent 'CGI::Snapp';),
 			'pragma'  => 'parent',
 			'version' => undef,
@@ -43,6 +43,14 @@ sub expected {
 			'version' => undef,
 			'imports' => [qw(capture)],
 			'module'  => 'Capture::Tiny'
+		},
+		{
+			'direct'  => 0,
+			'content' => q(use parent 'CGI::Snapp';),
+			'pragma'  => '',
+			'version' => undef,
+			'imports' => [],
+			'module'  => 'CGI::Snapp'
 		},
 	];
 	}


### PR DESCRIPTION
```
$ make test
/usr/bin/perl "-MTest::Manifest" "-e" "run_t_manifest(0, 'blib/lib', 'blib/arch',  )"
t/load.t .......... ok
t/pod.t ........... ok
t/pod_coverage.t .. ok
t/get_modules.t ... ok
t/imports.t ....... ok
t/versions.t ...... ok

#   Failed test 'The data structures match'
#   at t/rt/79273.t line 26.
#     Structures begin differing at:
#          $got->[0]{direct} = '1'
#     $expected->[0]{direct} = '0'
# Looks like you failed 1 test of 6.
t/rt/79273.t ...... 
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/6 subtests 

Test Summary Report
-------------------
t/rt/79273.t    (Wstat: 256 Tests: 6 Failed: 1)
  Failed test:  6
  Non-zero exit status: 1
Files=7, Tests=41,  1 wallclock secs ( 0.02 usr  0.00 sys +  0.36 cusr  0.04 csys =  0.42 CPU)
Result: FAIL
Failed 1/7 test programs. 1/41 subtests failed.
make: *** [test_dynamic] Error 1
```


Fix for "use parent" from commit b518b977 seems to have been lost in commit b490d577 ("reindent code"); test t/rt/79273.t is only run when Test::Manifest is present, hence the test failure does not always show up.